### PR TITLE
fix: issue with saving non-object values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Narrat changelog
 
+## [2.10.8] Fix to saves for non-object values
+
+A bug had sneaked in where non-object values (strings, numbers, booleans) were not saved properly in the save file.
+
 ## [2.10.7] Passing arguments to sprite `onClick`
 
 Arguments can now be passed to the `onClick` property of a sprite, by passing a string with the label and space-separated arguments.

--- a/packages/narrat/package.json
+++ b/packages/narrat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narrat",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "description": "narrat narrative engine",
   "main": "dist/narrat.umd.js",
   "module": "dist/narrat.es.js",

--- a/packages/narrat/src/stores/vm-store.ts
+++ b/packages/narrat/src/stores/vm-store.ts
@@ -100,6 +100,8 @@ export const useVM = defineStore('vm', {
               _entityType: value._entityType,
               id: value.id,
             };
+          } else {
+            return value;
           }
         }),
       };


### PR DESCRIPTION
Turns out a missing else in a predicate during saving was skipping non-object values