### PR TITLE
Apply configured audio file volume to played music and sound

### DIFF
--- a/demo-template/public/data/audio.yaml
+++ b/demo-template/public/data/audio.yaml
@@ -8,6 +8,7 @@ files:
   click:
     src: audio/click.ogg
   game_start:
+    volume: 0.9
     src: audio/game_start.ogg
   failure:
     src: audio/failure.ogg

--- a/docs/features/audio.md
+++ b/docs/features/audio.md
@@ -9,7 +9,7 @@ description: This guide explains how to use the audio features of narrat to play
 
 The `play` function plays audio, either music or sounds.
 
-To use the `play` function, the game needs to have audio files loaded by adding them to the config file:
+To use the `play` function, the game needs to have audio files loaded by adding them to the audio config file, usually located at `data/audio.yaml`:
 
 ```yaml
 files:
@@ -22,6 +22,7 @@ files:
   click:
     src: audio/click.ogg
   game_start:
+    volume: 0.9
     src: audio/game_start.ogg
   failure:
     src: audio/failure.ogg
@@ -35,6 +36,8 @@ audioTriggers:
   onPressStart: game_start
   onSkillCheckFailure: failure
 ```
+
+The path of the audio configuration yaml can be changed in the base `config.yaml`:
 
 ```yaml
 audio: data/audio.yaml

--- a/packages/narrat/examples/games/default/data/audio.yaml
+++ b/packages/narrat/examples/games/default/data/audio.yaml
@@ -8,6 +8,7 @@ files:
   click:
     src: audio/click.ogg
   game_start:
+    volume: 0.9
     src: audio/game_start.ogg
   failure:
     src: audio/failure.ogg

--- a/packages/narrat/examples/games/demo/data/audio.yaml
+++ b/packages/narrat/examples/games/demo/data/audio.yaml
@@ -8,6 +8,7 @@ files:
   click:
     src: audio/click.ogg
   game_start:
+    volume: 0.9
     src: audio/game_start.ogg
   failure:
     src: audio/failure.ogg

--- a/packages/narrat/src/stores/audio-store.ts
+++ b/packages/narrat/src/stores/audio-store.ts
@@ -173,7 +173,7 @@ export const useAudio = defineStore('audio', {
           // newAudio.volume(0.5, newId);
           newAudio.fade(
             0,
-            this.modeVolume(mode),
+            this.modeVolume(mode) * newAudio.volume(),
             audioConfig().options.musicFadeInTime * 1000,
             newId,
           );

--- a/packages/narrat/src/stores/audio-store.ts
+++ b/packages/narrat/src/stores/audio-store.ts
@@ -180,7 +180,7 @@ export const useAudio = defineStore('audio', {
         }
       } else if (mode === 'sound') {
         const newId = newAudio.play();
-        newAudio.volume(this.modeVolume(mode), newId);
+        newAudio.volume(this.modeVolume(mode) * newAudio.volume(), newId);
         this.setAudioChannel(mode, channelIndex, {
           audio,
           howlerId: newId,


### PR DESCRIPTION
The volume as set in the audio file configuration is now used when playing the audio files.

I have added an example of using the volume attribute to the documentation and the corresponding template and example audio configs. 