### PR TITLE
fix: hidden choices keyboard selection issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Narrat changelog
 
+## [2.11.1] Small bugfixes
+
+* fix: there was an issue where it was possible to select a "hidden" choice (choice that didn't pass a condition) by pressing the corresponding keyboard number
+
 ## [2.11.0] Audio volume improvement and saves fix
 
 * Audio volume in an individual audio file's config wasn't used properly and is now correctly mixed with the relevant volume for channels (by [@jornvandebeek](https://github.com/jornvandebeek))

--- a/packages/narrat/examples/games/default/scripts/default.nar
+++ b/packages/narrat/examples/games/default/scripts/default.nar
@@ -1,8 +1,21 @@
 main:
   // Note: This script is a dev testing thing and is a mess of random test commands, not meant to make sense
-  set config.characters.characters.player.name "Someone"
-  talk player idle "I like @@bread"
+  // jump test_choice_conditions
+  // set config.characters.characters.player.name "Someone"
+  // talk player idle "I like @@bread"
   jump quest_demo
+
+test_choice_conditions:
+  set data.falseCondition false
+  choice:
+    "Test"
+    "Option 1":
+      "Hello 1"
+    "Option 2":
+      "Hello 2"
+    "Option 3" if $data.falseCondition:
+      "Hello 3"
+  "End of test"
 
 test_skill_checks:
   choice:

--- a/packages/narrat/package.json
+++ b/packages/narrat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narrat",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "narrat narrative engine",
   "main": "dist/narrat.umd.js",
   "module": "dist/narrat.es.js",

--- a/packages/narrat/src/dialog-box.vue
+++ b/packages/narrat/src/dialog-box.vue
@@ -240,10 +240,10 @@ export default defineComponent({
             choice = 7;
             break;
         }
-        if (choice !== -1) {
+        if (choice !== -1  && this.choices && choice < this.choices.length) {
           if (this.choices && choice < this.choices.length) {
             this.chooseOption(this.choices[choice]);
-          } else {
+          } else if (choice === 0) {
             this.chooseOption(choice);
           }
         }


### PR DESCRIPTION
- fix: hidden choice keyboard selection
- chore: 2.11.1 changelog

Fixes a bug where a hidden choice (disabled by a condition) could still be selected by pressing the corresponding keyboard number key.

> ⚠️ NOTE: use notes like this to emphasize something about the PR. This could include other PRs this PR is built on top of; new or removed environment variables; reasons for why the PR is on hold; or anything else you would like to draw attention to.

## Checklist

- [ ] Linked an issue for this PR (create one if needed)
- [ ] Have you followed the guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file?
- [ ] Have you checked if there are breaking changes in this PR, and if so mentioned them below?
- [ ] PR passes tests (`npm run test`)
- [ ] PR passes linter (`npm run lint`)
- [ ] PR passes type checking (`npm run check-types`)
- [ ] PR builds (`npm run build`)

** Feel free to delete sections that aren't relevant to your changes **

## Problem

_What problem are you trying to solve?_:

_Link to related issue_: #123 (Please create a relevant if there isn't one)

## Solution

_How did you solve the problem?_

## Before & After Screenshots

(Include if relevant)
**BEFORE**:
[insert screenshot here]

**AFTER**:
[insert screenshot here]

## Other changes (e.g. bug fixes, UI tweaks, small refactors)

_Any additional explanations needed about changes_:

## Breaking Changes

_Do any of the changes cause breaking changes for users? For example: Changes in the config, in scripting syntax..._:

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

## New dependencies

_Any new dependencies added?_:
