### PR TITLE
feat(saving): new dynamic label to run on game load

### DIFF
--- a/packages/narrat/examples/games/default/data/config.yaml
+++ b/packages/narrat/examples/games/default/data/config.yaml
@@ -37,6 +37,7 @@ layout:
 saves:
   mode: manual
   slots: 10
+  runOnReload: 'test_label_reload'
 screens: data/screens.yaml
 buttons: data/buttons.yaml
 skills: data/skills.yaml

--- a/packages/narrat/examples/games/default/scripts/default.nar
+++ b/packages/narrat/examples/games/default/scripts/default.nar
@@ -10,6 +10,23 @@ main:
   // talk player idle "Global counter is %{$global.counter}"
   jump quest_demo
 
+test_label_reload:
+  run set_config_overrides
+  "Game reloaded"
+  talk player idle "Welcome back"
+
+set_config_overrides:
+  set config.characters.characters.player.name $data.playerName
+
+test_edit_config:
+  set data.playerName (text_field "Enter your name")
+  run set_config_overrides
+  run verify_edit_config
+
+verify_edit_config:
+  talk player idle "It's me, %{$config.characters.characters.player.name}"
+  jump achievements_demo
+
 test_roll_if:
   set data.n 2
   choice:

--- a/packages/narrat/src/config/common-config.ts
+++ b/packages/narrat/src/config/common-config.ts
@@ -92,6 +92,7 @@ export type DebuggingConfig = Static<typeof DebuggingConfigSchema>;
 export const SavesConfigSchema = Type.Object({
   mode: Type.String(),
   slots: Type.Number(),
+  runOnReload: Type.Optional(Type.String()),
 });
 export type SavesConfig = Static<typeof SavesConfigSchema>;
 

--- a/packages/narrat/src/stores/main-store.ts
+++ b/packages/narrat/src/stores/main-store.ts
@@ -40,6 +40,7 @@ import { isPromise } from '@/utils/type-utils';
 import { useMenu } from './menu-store';
 import { useScreenObjects } from './screen-objects-store';
 import { useAchievements } from './achievements-store';
+import { useConfig } from './config-store';
 
 export function defaultAppOptions(): AppOptions {
   return {
@@ -246,6 +247,10 @@ export const useMain = defineStore('main', {
         this.setLoadedData(save.saveData);
         useAudio().reloadAudio(save.saveData.audio);
         const vm = useVM();
+        const runOnReload = getConfig().saves.runOnReload;
+        if (typeof runOnReload === 'string') {
+          await useVM().runLabelFunction(runOnReload);
+        }
         vm.jumpToLabel(save.saveData.vm.lastLabel);
       }
     },


### PR DESCRIPTION
New feature to run a config-specified label when the player loads a save, so that dynamic values that can't be saved can be setup again