### PR TITLE
feat(skillChecks): new option to control whether rolls fail on equality or not

### DIFF
--- a/demo-template/package.json
+++ b/demo-template/package.json
@@ -4,7 +4,7 @@
   "description": "Template for Narrat game engine",
   "main": "electron-main.js",
   "engines": {
-    "node": "16.x"
+    "node": ">=16.x"
   },
   "build": {
     "files": [

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -88,6 +88,7 @@ options:
   showDifficultyWithoutModifiers: false # Whether to show the original difficulty without modifiers applied on the skill check
   totalRollIsHighest: false # Uses only the highest roll to do the final skill check comparison, instead of adding up all rolls
   totalRollIsLowest: false # Uses only the lowest roll to do the final skill check comparison, instead of adding up all rolls
+  failOnRollsEqualToThreshold: false # [OPTIONAL, default true]: If this option is on, rolls will fail if they're equal to the score to beat. Otherwise they will succeed. This effectively makes it use `>` instead of `>=` for the comparison.
   difficultyText: # Text to show for each band of difficulty level
     - [2, 'Very Easy']
     - [4, 'Easy']

--- a/packages/narrat/examples/games/default/data/skillchecks.yaml
+++ b/packages/narrat/examples/games/default/data/skillchecks.yaml
@@ -9,6 +9,7 @@ options:
   showDifficultyWithoutModifiers: false # Whether to show the original difficulty without modifiers applied on the skill check
   totalRollIsHighest: false # Uses only the highest roll to do the final skill check comparison, instead of adding up all rolls
   totalRollIsLowest: false # Uses only the lowest roll to do the final skill check comparison, instead of adding up all rolls
+  failOnRollsEqualToThreshold: false # [OPTIONAL, default true]: If this option is on, rolls will fail if they're equal to the score to beat. Otherwise they will succeed. This effectively makes it use `>` instead of `>=` for the comparison.
   difficultyText: # Text to show for each band of difficulty level
     - [2, 'Very Easy']
     - [4, 'Easy']

--- a/packages/narrat/src/config/skillchecks-config.ts
+++ b/packages/narrat/src/config/skillchecks-config.ts
@@ -12,6 +12,7 @@ export const SkillCheckOptionsConfigSchema = Type.Object({
   showDifficultyWithoutModifiers: Type.Boolean(),
   finalRollIsHighest: Type.Optional(Type.Boolean()),
   finalRollIsLowest: Type.Optional(Type.Boolean()),
+  failOnRollsEqualToThreshold: Type.Optional(Type.Boolean()),
 });
 
 export type SkillCheckOptionsConfig = Static<

--- a/packages/narrat/src/utils/skillchecks.test.ts
+++ b/packages/narrat/src/utils/skillchecks.test.ts
@@ -33,6 +33,7 @@ const skillChecksConfigMock: SkillChecksConfig = {
     showDifficultyWithoutModifiers: false,
     finalRollIsHighest: false,
     finalRollIsLowest: false,
+    failOnRollsEqualToThreshold: false,
     difficultyText: [
       [2, 'Very Easy'],
       [4, 'Easy'],
@@ -160,18 +161,30 @@ describe('checkIfRollSucceeded', () => {
     const result = checkIfRollSucceeded(4, 6);
     expect(result).toBe(false);
   });
-  it('succeeds if the roll is equal or above the threshold', () => {
+  it('succeeds if the roll is above the threshold', () => {
     const result = checkIfRollSucceeded(6, 4);
     expect(result).toBe(true);
-    const resultEqual = checkIfRollSucceeded(4, 4);
-    expect(resultEqual).toBe(true);
   });
-  it('succeeds if the roll is below the threshold if the option is given', () => {
+  it('Succeeds if the roll is equal to the threshold by default', () => {
+    const result = checkIfRollSucceeded(4, 4);
+    expect(result).toBe(true);
+  });
+  it('succeeds if the roll is below the threshold if the `successOnRollsBelowThreshold` option is true', () => {
     skillChecksConfig().options.successOnRollsBelowThreshold = true;
     const result = checkIfRollSucceeded(4, 6);
     expect(result).toBe(true);
     const resultFail = checkIfRollSucceeded(6, 4);
     expect(resultFail).toBe(false);
+    const resultEqual = checkIfRollSucceeded(4, 4);
+    expect(resultEqual).toBe(true);
+  });
+  it('Fails if the roll is equal to the threshold and the `failOnRollsEqualToThreshold` option is true', () => {
+    skillChecksConfig().options.failOnRollsEqualToThreshold = true;
+    let result = checkIfRollSucceeded(4, 4);
+    expect(result).toBe(false);
+    skillChecksConfig().options.successOnRollsBelowThreshold = true;
+    result = checkIfRollSucceeded(4, 4);
+    expect(result).toBe(false);
   });
 });
 
@@ -196,7 +209,7 @@ describe('calculateSkillCheckRoll', () => {
       rolls: fakeRolls,
     });
   });
-  it('returns the highest roll if the option is given', () => {
+  it('returns the highest roll if the `finalRollIsHighest` option is given', () => {
     let i = 0;
     Math.random = () => (i++ === 0 ? 0.5 : 0.1);
     skillChecksConfig().options.finalRollIsHighest = true;
@@ -207,7 +220,7 @@ describe('calculateSkillCheckRoll', () => {
       rolls: fakeRolls,
     });
   });
-  it('returns the lowest roll if the option is given', () => {
+  it('returns the lowest roll if the `finalRollIsLowest` option is given', () => {
     let i = 0;
     Math.random = () => (i++ === 0 ? 0.5 : 0.1);
     skillChecksConfig().options.finalRollIsLowest = true;
@@ -253,7 +266,7 @@ describe('resolveSkillCheck', () => {
     });
     expect(result).toBe(true);
   });
-  it('windsNeeded mode fails if not enough rolls succeeded', () => {
+  it('windsNeeded mode fails if not enough rolls succeeded, even if one of them succeeded', () => {
     // first roll will be 2, second will be 5
     let i = 0;
     Math.random = () => (i++ === 0 ? 0.1 : 0.5);

--- a/packages/narrat/src/utils/skillchecks.ts
+++ b/packages/narrat/src/utils/skillchecks.ts
@@ -208,12 +208,12 @@ export function resolveSkillCheck(params: SkillCheckParams): boolean {
 
 export function checkIfRollSucceeded(roll: number, value: number) {
   const { options } = skillChecksConfig();
-  let success = true;
-  if (roll < value) {
-    success = false;
-  }
+  let success = roll >= value;
   if (options.successOnRollsBelowThreshold) {
-    success = !success;
+    success = roll <= value;
+  }
+  if (options.failOnRollsEqualToThreshold && roll === value) {
+    success = false;
   }
   return success;
 }


### PR DESCRIPTION
New feature to use the `failOnRollsEqualToThreshold` skillChecks option to control whether rolls fail on equality
