### PR TITLE
docs: docs and template updates for config files migration

### DIFF
--- a/docs/features/config-hot-reloading.md
+++ b/docs/features/config-hot-reloading.md
@@ -13,10 +13,47 @@ To use this new system, the yaml files for the config need to be moved to the `s
 
 ## How to migrate to the new system
 
+::: tip
+This is only necessary if your game was created prior to 3.6.0. New games already use the new system. You can keep using the old system if you want, though in the future support for it might be dropped.
+:::
+
 The example games have been updated to use the new system, so they can be used as an example. To use the new system:
 
-1. Move your yaml files to a `config` folder in the `src` folder
-2. Create a `index.ts` file in the `src/config` folder which exports all the config files as a single object, like this:
+1. Update your narrat version **and vite-plugin-narrat** versions to 3.6.0 or above. The `vite-plugin-narrat` is necessary for the project to understand yaml files as "code" files.
+
+Either change their version in package.json manually, or run:
+
+`npm install narrat@latest vite-plugin-narrat@latest`
+
+2. Add info about yaml files to the `shims-narrat.d.ts` file in `src/types` (which previously only had info about `.narrat` files). This tells your IDE what is in the yaml files:
+
+```ts
+// shims-narrat.d.ts
+
+declare module '*.narrat' {
+  import { NarratScript } from './app-types';
+  const narratScript: NarratScript;
+  export default narratScript;
+}
+
+declare module '*.yaml' {
+  // [!code ++]
+  import { NarratYaml } from './app-types'; // [!code ++]
+  const narratYaml: NarratYaml; // [!code ++]
+  export default narratYaml; // [!code ++]
+} // [!code ++]
+
+// This bit if you want to be able to use `.yml` instead of `.yaml`:
+declare module '*.yml' {
+  // [!code ++]
+  import { NarratYaml } from './app-types'; // [!code ++]
+  const narratYaml: NarratYaml; // [!code ++]
+  export default narratYaml; // [!code ++]
+} // [!code ++]
+```
+
+3. Move your yaml files to a `config` folder in the `src` folder
+4. Create a `index.ts` file in the `src/config` folder which exports all the config files as a single object, like this:
 
 ```ts
 import achievements from './achievements.yaml';
@@ -56,7 +93,7 @@ export default defaultGameConfigs;
 You may have more or less files to import depending on which config files your game uses.
 :::
 
-3. Then, in `index.ts`, the new config object needs to be imported and passed, and the old one can be removed:
+5. Then, in `index.ts`, the new config object needs to be imported and passed, and the old one can be removed:
 
 ```ts
 import 'narrat/dist/style.css';
@@ -80,3 +117,5 @@ window.addEventListener('load', () => {
   });
 });
 ```
+
+> :tada: This should be all you need, now your config files are imported as code, allowing vite to hot reload them. Some parts of the engine should now live-update when config values change, though that might not work everywhere (it depends how the config is used internally)

--- a/packages/create-narrat/template/package.json
+++ b/packages/create-narrat/template/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "electron-squirrel-startup": "^1.0.0",
     "es6-promise": "^4.2.8",
-    "narrat": "3.5.1",
+    "narrat": "3.6.0",
     "pinia": "^2.1.4",
     "steamworks.js": "^0.2.0",
     "vue": "^3.3.4"
@@ -49,7 +49,7 @@
     "shx": "^0.3.4",
     "typescript": "^5.1.6",
     "vite": "^4.4.2",
-    "vite-plugin-narrat": "3.5.1"
+    "vite-plugin-narrat": "3.6.0"
   },
   "config": {
     "forge": {

--- a/packages/create-narrat/template/types/shims-narrat.d.ts
+++ b/packages/create-narrat/template/types/shims-narrat.d.ts
@@ -5,3 +5,14 @@ declare module "*.narrat" {
   const narratScript: NarratScript;
   export default narratScript;
 }
+
+declare module "*.yaml" {
+  import { NarratYaml } from "narrat";
+  const narratYaml: NarratYaml;
+  export default narratYaml;
+}
+declare module "*.yml" {
+  import { NarratYaml } from "narrat";
+  const narratYaml: NarratYaml;
+  export default narratYaml;
+}


### PR DESCRIPTION
Update to docs for missing info on migration to new config files format, and also updated the narrat shim for yaml files in template as it was forgotten