### PR TITLE
feat: save data prefix for custom save file namespacing

### DIFF
--- a/packages/narrat/src/main.ts
+++ b/packages/narrat/src/main.ts
@@ -50,6 +50,9 @@ export async function startApp(optionsInput: AppOptionsInput) {
   addDirectives(app);
   const config = await loadConfig(options);
   useConfig().setConfig(config);
+  if (optionsInput.savePathPrefix) {
+    useConfig().setSavePathPrefix(optionsInput.savePathPrefix);
+  }
   getSaveFile();
   useInputs().setupInputs();
   vm.pinia = pinia;

--- a/packages/narrat/src/stores/config-store.ts
+++ b/packages/narrat/src/stores/config-store.ts
@@ -18,6 +18,8 @@ export interface ConfigStore {
   config: Config;
   // Record of modules being used for live reload, keyed by file id
   configModules: Record<ConfigKey, ConfigModule>;
+  // This needs to be able to be set at runtime just before the game loads, so we store it as its own value
+  savePathPrefix: string | null;
 }
 
 export const useConfig = defineStore('config', {
@@ -26,11 +28,15 @@ export const useConfig = defineStore('config', {
     return {
       config,
       configModules: {},
+      savePathPrefix: null,
     } as ConfigStore;
   },
   actions: {
     async setConfig(config: Config) {
       this.config = config;
+    },
+    setSavePathPrefix(prefix: string) {
+      this.savePathPrefix = prefix;
     },
     extendConfig(config: DeepPartial<Config>) {
       this.config = deepmerge(this.config, config) as Config;

--- a/packages/narrat/src/types/app-types.ts
+++ b/packages/narrat/src/types/app-types.ts
@@ -48,6 +48,7 @@ export interface ConfigFiles {
 export interface AppOptions {
   baseAssetsPath?: string;
   baseDataPath?: string;
+  savePathPrefix?: string;
   configPath?: string;
   scripts: NarratScript[];
   logging?: boolean;

--- a/packages/narrat/src/utils/save-helpers.ts
+++ b/packages/narrat/src/utils/save-helpers.ts
@@ -9,11 +9,18 @@ import {
 } from '@/types/game-save';
 import { error, warning } from './error-handling';
 import { randomId } from './randomId';
+import { useConfig } from '@/stores/config-store';
 export const CURRENT_SAVE_VERSION = '3.4.0';
 
 export function saveFileName(): string {
-  return `NARRAT_SAVE_${getCommonConfig().saveFileName}`;
+  let base = `NARRAT_SAVE_`;
+  let prefix = useConfig().savePathPrefix;
+  if (prefix) {
+    base += `${prefix}_`;
+  }
+  return `${base}${getCommonConfig().saveFileName}`;
 }
+
 const oldSaveFileName = 'gameSave';
 
 let saveFile: SaveFile;


### PR DESCRIPTION
Allows the game to give a custom namespace to save data by passing the `savePathPrefix` option to `startApp`