### PR TITLE
feat: show old choices feature

### DIFF
--- a/docs/features/dialog-panel.md
+++ b/docs/features/dialog-panel.md
@@ -29,6 +29,7 @@ width: 475
 height: 680
 hideDuringTransition: false
 showAfterScriptEnd: false
+showOldChoices: false
 ```
 
 - `textSpeed`: [number] The speed at which text appears in the dialog panel, in characters per second. Defaults to 30. If `animateText` is off, this still controls the speed of auto play. Players can override this setting in the system menu
@@ -41,6 +42,7 @@ showAfterScriptEnd: false
 - `height`: [number] The height of the dialog panel, in pixels.
 - `hideDuringTransition`: [boolean] Whether the dialog panel should be hidden during screen transitions. Defaults to true.
 - `showAfterScriptEnd`: [boolean] Whether the dialog panel should stay on even if the narrat script ends. Defaults to false.
+- `showOldChoices`: [boolean] [optional] [default: false] If turned on, choice options for past choices will appear in the dialog history instead of being deleted
 
 ## Controlling when the dialog panel appears
 

--- a/packages/narrat/src/config/common-config.ts
+++ b/packages/narrat/src/config/common-config.ts
@@ -27,6 +27,7 @@ export const DialogPanelConfigSchema = Type.Optional(
     historyLength: Type.Optional(Type.Number()),
     allowHistoryToggling: Type.Optional(Type.Boolean()),
     showAfterScriptEnd: Type.Optional(Type.Boolean()),
+    showOldChoices: Type.Optional(Type.Boolean()),
   }),
 );
 export type DialogPanelConfig = Static<typeof DialogPanelConfigSchema>;

--- a/packages/narrat/src/css/main.css
+++ b/packages/narrat/src/css/main.css
@@ -57,6 +57,7 @@
 
   --dialog-choice-color: orange;
   --dialog-choice-seen-before-color: grey;
+  --dialog-choice-old-color: rgb(197, 197, 197);
   --dialog-choice-key-color: red;
   --dialog-choice-hover-color: var(--text-color);
 

--- a/packages/narrat/src/examples/default/config/common.yaml
+++ b/packages/narrat/src/examples/default/config/common.yaml
@@ -19,6 +19,7 @@ dialogPanel:
   historyLength: 200 # The number of dialogue lines to keep in the history
   hideDuringTransition: true # Setting this to true will make the dialog panel hide during screen transitions
   showAfterScriptEnd: false # Setting this to true will make the dialog panel stay on even if the narrat script ends
+  showOldChoices: false
 settings:
   customSettings:
     playerName:

--- a/packages/narrat/src/utils/save-helpers.ts
+++ b/packages/narrat/src/utils/save-helpers.ts
@@ -14,7 +14,7 @@ export const CURRENT_SAVE_VERSION = '3.4.0';
 
 export function saveFileName(): string {
   let base = `NARRAT_SAVE_`;
-  let prefix = useConfig().savePathPrefix;
+  const prefix = useConfig().savePathPrefix;
   if (prefix) {
     base += `${prefix}_`;
   }


### PR DESCRIPTION
Added a config option (showOldChoices, defualt 'false') to make choices stay displayed even after being chosen, with new css variables.