### PR TITLE
fix: tooltips supporting sentences

### DIFF
--- a/docs/features/tooltips.md
+++ b/docs/features/tooltips.md
@@ -4,6 +4,10 @@ Tooltips are a feature that allows games to show information tooltips when hover
 
 They are fully configurable and automated. All you need is to create a list of tooltips, and the engine will make them appear automatically.
 
+::: danger
+As of 4.1.0, if you were using the old tooltip system before, tooltips now have a suffix. You can either change nothing and keep using the old system, or update your config and tooltips and add `useNewSystem: true` to the `tooltips.yaml` file, and then add a suffix to all keywords in your tooltips.
+:::
+
 ![Example tooltip](./tooltips/tooltip.png)
 _This tooltip appears when the player hovers the word bread_.
 
@@ -18,23 +22,31 @@ Tooltips are created and configured in the `tooltips.yaml` file:
 ```yaml
 options:
   width: 350
-  keywordsPrefix: '@@'
+  keywordsPrefix: '@t{'
+  keywordsSuffix: '}@'
 tooltips:
   - keywords: [bread, breads]
     title: Bread
     description: Bread is a staple food prepared from a dough of flour (usually wheat) and water, usually by baking. Throughout recorded history and around the world, it has been an important part of many cultures' diet. It is one of the oldest human-made foods, having been of significance since the dawn of agriculture, and plays an essential role in both religious rituals and secular culture.
 ```
 
-Then, in `config.yaml` add the path to the file:
+Remember to include the `tooltips.yaml` file in your `src/configs/index.ts` file, so it gets loaded by the engine.
+
+::: info
+Tooltips keywords can be sentences with space, accents, etc. Simply wrap the keyword in quotes, like this:
 
 ```yaml
-tooltips: data/tooltips.yaml
+tooltips:
+  - keywords: ['sentence tooltip']
 ```
+
+:::
 
 ### General tooltips config
 
 - `width`: Width of tooltip box in pixels
-- `keywordsPrefix`: The prefix to use before words in scripts to make the tooltip appear
+- `keywordsPrefix`: The prefix to use before words in scripts to make the tooltip appear. Use something that won't appear in normal text, like `@t{`.
+- `keywordsSuffix`: The suffix to use after words in scripts to make the tooltip appear. Use something that won't appear in normal text, like `}@`.
 
 ### Options for individual tooltips
 
@@ -46,7 +58,7 @@ Then, to use in scripts, for example:
 
 ```narrat
 main:
-  talk player idle "I like @@bread"
+  talk player idle "I like @t{bread}@"
 ```
 
 Having one of the keywords defined in the tooltips with the `keywordsPrefix` before it will make it be detected as a keyword and show the tooltip
@@ -71,3 +83,5 @@ tooltips:
 ```
 
 Any of the above css options can be used to make tooltips get custom css classes
+
+## Old tooltip system

--- a/packages/create-narrat/template-games/demo/src/config/index.ts
+++ b/packages/create-narrat/template-games/demo/src/config/index.ts
@@ -9,6 +9,7 @@ import skills from './skills.yaml';
 import skillChecks from './skillchecks.yaml';
 import fonts from './fonts.yaml';
 import localization from './localization.yaml';
+import tooltips from './tooltips.yaml';
 
 import { ModuleConfigInput } from 'narrat';
 
@@ -24,5 +25,6 @@ const gameConfigs: ModuleConfigInput = {
   skillChecks,
   fonts,
   localization,
+  tooltips,
 };
 export default gameConfigs;

--- a/packages/create-narrat/template-games/demo/src/config/tooltips.yaml
+++ b/packages/create-narrat/template-games/demo/src/config/tooltips.yaml
@@ -5,16 +5,6 @@ options:
   keywordsSuffix: '}@'
   useNewSystem: true
 tooltips:
-  - keywords: ['sentence tooltip']
-    title: Sentence Tooltip
-    styling:
-      textCssClass: test
-      titleCssClass: test
-      cssClass: test
-    description: This is a tooltip that appears when you hover over a sentence.
-  - keywords: ['tooltip with accénts']
-    title: Tooltip with Accénts
-    description: This tooltip has accents in its title.
   - keywords: [bread, breads]
     title: Bread 🍞🥖
     styling:

--- a/packages/create-narrat/template-games/empty/src/config/index.ts
+++ b/packages/create-narrat/template-games/empty/src/config/index.ts
@@ -9,6 +9,7 @@ import skills from './skills.yaml';
 import skillChecks from './skillchecks.yaml';
 import fonts from './fonts.yaml';
 import localization from './localization.yaml';
+import tooltips from './tooltips.yaml';
 
 import { ModuleConfigInput } from 'narrat';
 
@@ -24,5 +25,6 @@ const gameConfigs: ModuleConfigInput = {
   skillChecks,
   fonts,
   localization,
+  tooltips,
 };
 export default gameConfigs;

--- a/packages/create-narrat/template-games/empty/src/config/tooltips.yaml
+++ b/packages/create-narrat/template-games/empty/src/config/tooltips.yaml
@@ -5,16 +5,6 @@ options:
   keywordsSuffix: '}@'
   useNewSystem: true
 tooltips:
-  - keywords: ['sentence tooltip']
-    title: Sentence Tooltip
-    styling:
-      textCssClass: test
-      titleCssClass: test
-      cssClass: test
-    description: This is a tooltip that appears when you hover over a sentence.
-  - keywords: ['tooltip with accénts']
-    title: Tooltip with Accénts
-    description: This tooltip has accents in its title.
   - keywords: [bread, breads]
     title: Bread 🍞🥖
     styling:

--- a/packages/create-narrat/template/src/strings/strings_en.yaml
+++ b/packages/create-narrat/template/src/strings/strings_en.yaml
@@ -33,6 +33,9 @@ translation:
       next_subtab: Next Subtab
       decrease_setting: Decrease
       increase_setting: Increase
+    dialog_box:
+      continue: Continue
+      submit_text_field: Confirm
     main_menu:
       continue: Continue
       start_new_game: Start a new game

--- a/packages/narrat/src/config/tooltips-config.ts
+++ b/packages/narrat/src/config/tooltips-config.ts
@@ -11,8 +11,11 @@ export const TooltipsConfigSchema = Type.Object({
     delay: Type.Optional(Type.Number()),
     width: Type.Number(),
     keywordsPrefix: Type.String(),
+    keywordsSuffix: Type.Optional(Type.String()),
     screenEdgesMinimumMargin: Type.Optional(Type.Number()),
     styling: Type.Optional(TooltipStylingSchema),
+    // Old system had a prefix and no suffix
+    useOldSystem: Type.Optional(Type.Boolean()),
   }),
   tooltips: Type.Array(
     Type.Object({

--- a/packages/narrat/src/config/tooltips-config.ts
+++ b/packages/narrat/src/config/tooltips-config.ts
@@ -15,7 +15,7 @@ export const TooltipsConfigSchema = Type.Object({
     screenEdgesMinimumMargin: Type.Optional(Type.Number()),
     styling: Type.Optional(TooltipStylingSchema),
     // Old system had a prefix and no suffix
-    useOldSystem: Type.Optional(Type.Boolean()),
+    useNewSystem: Type.Optional(Type.Boolean()),
   }),
   tooltips: Type.Array(
     Type.Object({

--- a/packages/narrat/src/examples/default/config/tooltips.yaml
+++ b/packages/narrat/src/examples/default/config/tooltips.yaml
@@ -1,8 +1,19 @@
 options:
   delay: 0
   width: 350
-  keywordsPrefix: '@@'
+  keywordsPrefix: '@t{'
+  keywordsSuffix: '}@'
 tooltips:
+  - keywords: ['sentence tooltip']
+    title: Sentence Tooltip
+    styling:
+      textCssClass: test
+      titleCssClass: test
+      cssClass: test
+    description: This is a tooltip that appears when you hover over a sentence.
+  - keywords: ['Tooltip with accénts']
+    title: Tooltip with Accénts
+    description: This tooltip has accents in its title.
   - keywords: [bread, breads]
     title: Bread 🍞🥖
     styling:

--- a/packages/narrat/src/examples/default/config/tooltips.yaml
+++ b/packages/narrat/src/examples/default/config/tooltips.yaml
@@ -3,6 +3,7 @@ options:
   width: 350
   keywordsPrefix: '@t{'
   keywordsSuffix: '}@'
+  useOldSystem: false
 tooltips:
   - keywords: ['sentence tooltip']
     title: Sentence Tooltip
@@ -11,7 +12,7 @@ tooltips:
       titleCssClass: test
       cssClass: test
     description: This is a tooltip that appears when you hover over a sentence.
-  - keywords: ['Tooltip with accénts']
+  - keywords: ['tooltip with accénts']
     title: Tooltip with Accénts
     description: This tooltip has accents in its title.
   - keywords: [bread, breads]

--- a/packages/narrat/src/examples/default/scripts/scripts.ts
+++ b/packages/narrat/src/examples/default/scripts/scripts.ts
@@ -16,6 +16,7 @@ import dialog from './test_dialog.narrat';
 import achievements from './test-achievements.narrat';
 import quests from './quests.narrat';
 import localization from './test_localization.narrat';
+import test_tooltips from './test_tooltips.narrat';
 
 export default [
   game,
@@ -36,4 +37,5 @@ export default [
   quests,
   achievements,
   localization,
+  test_tooltips,
 ];

--- a/packages/narrat/src/examples/default/scripts/test_tooltips.narrat
+++ b/packages/narrat/src/examples/default/scripts/test_tooltips.narrat
@@ -1,0 +1,3 @@
+test_tooltips:
+  "Hello, @t{sentence tooltip}@ hello."
+  "Test @t{Tooltip with accénts}@."

--- a/packages/narrat/src/examples/default/scripts/tooltips.narrat
+++ b/packages/narrat/src/examples/default/scripts/tooltips.narrat
@@ -1,2 +1,2 @@
-test_tooltips:
+test_old_tooltips:
   talk player idle "Hello @@bread !!!"

--- a/packages/narrat/src/examples/default/strings/strings_en.yaml
+++ b/packages/narrat/src/examples/default/strings/strings_en.yaml
@@ -33,6 +33,9 @@ translation:
       next_subtab: Next Subtab
       decrease_setting: Decrease
       increase_setting: Increase
+    dialog_box:
+      continue: Continue
+      submit_text_field: Confirm
     main_menu:
       continue: Continue
       start_new_game: Start a new game

--- a/packages/narrat/src/utils/tooltip-utils.ts
+++ b/packages/narrat/src/utils/tooltip-utils.ts
@@ -4,7 +4,8 @@ import { getWindow } from './getWindow';
 
 export function processTooltipsInText(text: string) {
   const conf = tooltipsConfig().options;
-  if (conf.useOldSystem) {
+  if (!conf.useNewSystem) {
+    // Old version without a suffix
     const prefix = tooltipsConfig().options.keywordsPrefix;
     const regex = new RegExp(`${prefix}(\\w*)`, 'gi');
     text = text.replace(regex, addTooltipToKeyword);

--- a/packages/narrat/src/utils/tooltip-utils.ts
+++ b/packages/narrat/src/utils/tooltip-utils.ts
@@ -3,10 +3,19 @@ import { useTooltips } from '@/stores/tooltip-store';
 import { getWindow } from './getWindow';
 
 export function processTooltipsInText(text: string) {
-  const prefix = tooltipsConfig().options.keywordsPrefix;
-  const regex = new RegExp(`${prefix}(\\w*)`, 'gi');
-  text = text.replace(regex, addTooltipToKeyword);
-  return text;
+  const conf = tooltipsConfig().options;
+  if (conf.useOldSystem) {
+    const prefix = tooltipsConfig().options.keywordsPrefix;
+    const regex = new RegExp(`${prefix}(\\w*)`, 'gi');
+    text = text.replace(regex, addTooltipToKeyword);
+    return text;
+  } else {
+    // New system uses both prefix and suffix to avoid potential issues
+    const prefix = tooltipsConfig().options.keywordsPrefix;
+    const suffix = tooltipsConfig().options.keywordsSuffix || '';
+    const regex = new RegExp(`${prefix}(.*)${suffix}`, 'gi');
+    text = text.replace(regex, addTooltipToKeyword);
+  }
 }
 
 getWindow().onTooltipEnter = (event: MouseEvent, keyword: string) => {

--- a/packages/narrat/src/utils/tooltip-utils.ts
+++ b/packages/narrat/src/utils/tooltip-utils.ts
@@ -15,6 +15,7 @@ export function processTooltipsInText(text: string) {
     const suffix = tooltipsConfig().options.keywordsSuffix || '';
     const regex = new RegExp(`${prefix}(.*)${suffix}`, 'gi');
     text = text.replace(regex, addTooltipToKeyword);
+    return text;
   }
 }
 


### PR DESCRIPTION
See the updated docs, there is a new suffix system for tooltips