### PR TITLE
Fixing Hidden Achievement Title Translation Bug

### DIFF
--- a/packages/narrat/src/components/achievements/achievement-tile.vue
+++ b/packages/narrat/src/components/achievements/achievement-tile.vue
@@ -54,7 +54,7 @@ const name = computed(() => {
   if (obtained.value || !conf.value.secret || !secretAchievements.censorName) {
     return conf.value.name;
   } else {
-    return 'Hidden Achievement';
+    return 'narrat.game_menu.achievements.hidden_achievement';
   }
 });
 const description = computed(() => {


### PR DESCRIPTION
Hidden Achievement title is now referenced using the hidden_achievement variable rather than a hard coded string.

## Checklist

- [x] Linked an issue for this PR (or no issue is relevant)
- [x] Have you followed the guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file?
- [x] Have you checked if there are breaking changes in this PR, and if so mentioned them below?

## Problem

Issue #390 recorded a bug regarding the hidden achievement title not translating to french after the language was switched from english to french.

## Solution

Line 57 of achievement-tile.vue located in packages/narrat/src/components/achievements had a statement returning a hard-coded string 'Hidden Achievement'
I modified the return statement to return 'narrat.game_menu.achievements.hidden_achievement' which will reference the correct hidden achievement title given the current language.

## Before & After Screenshots

**BEFORE**:
<img width="1352" height="642" alt="succès_caché_en_français" src="https://github.com/user-attachments/assets/1ee712d8-4005-4250-9f1e-3defcf9c4cdd" />

**AFTER**:
<img width="1352" height="642" alt="fixed_bug" src="https://github.com/user-attachments/assets/8c4ac142-e2d6-4ffb-af17-3d5b15a8fe14" />

## Other changes (e.g. bug fixes, UI tweaks, small refactors)

No additional changes were made.

## Breaking Changes

No breaking changes were made.
